### PR TITLE
separate install instructions

### DIFF
--- a/hosters/hetzner-cloud/README.md
+++ b/hosters/hetzner-cloud/README.md
@@ -1,0 +1,21 @@
+# Instructions
+
+1. Create a server with any distribution (Ubuntu for exemple) from the Hetzner UI
+2. In your server options on the Hetzner UI click on `Mount image`. Find the NixOS image and mount it
+3. You won't be able to ssh into your server. You will have to do the following steps by logging in with the Hetzner UI.
+  3.a On the top right of the server details click on the icon `>_`.
+  3.b fork this repo and replace your SSH public key in the script. Make a commit on a new branch for example.
+  3.c get the url of the script you created (should look like https://raw.github.com/YOUR_USER_NAME/nixos-install-scripts/YOUR_BRANCH_NAME/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh)
+  3.d paste the following command into your console gui `curl -L YOUR_URL | sudo bash`
+4. on your own computer you can now ssh into the newly created machine
+
+# Troubleshooting
+
+## SSH `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!`
+
+if you have sshed into your server before installing NixOS, you will have to remove the server from your .know-hosts file.
+Open the file (located in your .ssh directory) and delete the entry corresponding to the server.
+
+## Curl 404 error
+
+if you copy and paste a url from the Hetzner console GUI, some characters can get replaced (If you are using an English/US keyboard layout for example). Just replace the offending characters (check the punctuation especially, @:_ and the like)

--- a/hosters/hetzner-cloud/README.md
+++ b/hosters/hetzner-cloud/README.md
@@ -3,10 +3,10 @@
 1. Create a server with any distribution (Ubuntu for exemple) from the Hetzner UI.
 2. In your server options on the Hetzner UI click on `Mount image`. Find the NixOS image and mount it.
 3. You won't be able to ssh into your server. You will have to do the following steps by logging in with the Hetzner UI.
-- On the top right of the server details click on the icon `>_`.
-- fork this repo and replace your SSH public key in the script. Make a commit on a new branch for example.
-- get the url of the script you created (should look like https://raw.github.com/YOUR_USER_NAME/nixos-install-scripts/YOUR_BRANCH_NAME/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh).
-- paste the following command into your console gui `curl -L YOUR_URL | sudo bash`.
+  - On the top right of the server details click on the icon `>_`.
+  - fork this repo and replace your SSH public key in the script. Make a commit on a new branch for example.
+  - get the url of the script you created (should look like https://raw.github.com/YOUR_USER_NAME/nixos-install-scripts/YOUR_BRANCH_NAME/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh).
+  - paste the following command into your console gui `curl -L YOUR_URL | sudo bash`.
 4. on your own computer you can now ssh into the newly created machine.
 
 # Troubleshooting

--- a/hosters/hetzner-cloud/README.md
+++ b/hosters/hetzner-cloud/README.md
@@ -1,21 +1,21 @@
 # Instructions
 
-1. Create a server with any distribution (Ubuntu for exemple) from the Hetzner UI
-2. In your server options on the Hetzner UI click on `Mount image`. Find the NixOS image and mount it
+1. Create a server with any distribution (Ubuntu for exemple) from the Hetzner UI.
+2. In your server options on the Hetzner UI click on `Mount image`. Find the NixOS image and mount it.
 3. You won't be able to ssh into your server. You will have to do the following steps by logging in with the Hetzner UI.
-  3.a On the top right of the server details click on the icon `>_`.
-  3.b fork this repo and replace your SSH public key in the script. Make a commit on a new branch for example.
-  3.c get the url of the script you created (should look like https://raw.github.com/YOUR_USER_NAME/nixos-install-scripts/YOUR_BRANCH_NAME/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh)
-  3.d paste the following command into your console gui `curl -L YOUR_URL | sudo bash`
-4. on your own computer you can now ssh into the newly created machine
+- On the top right of the server details click on the icon `>_`.
+- fork this repo and replace your SSH public key in the script. Make a commit on a new branch for example.
+- get the url of the script you created (should look like https://raw.github.com/YOUR_USER_NAME/nixos-install-scripts/YOUR_BRANCH_NAME/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh)
+- paste the following command into your console gui `curl -L YOUR_URL | sudo bash`.
+4. on your own computer you can now ssh into the newly created machine.
 
 # Troubleshooting
 
 ## SSH `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!`
 
-if you have sshed into your server before installing NixOS, you will have to remove the server from your .know-hosts file.
+if you have already ssh-ed into your server before installing NixOS, you will have to remove the server from your .know-hosts file.
 Open the file (located in your .ssh directory) and delete the entry corresponding to the server.
 
 ## Curl 404 error
 
-if you copy and paste a url from the Hetzner console GUI, some characters can get replaced (If you are using an English/US keyboard layout for example). Just replace the offending characters (check the punctuation especially, @:_ and the like)
+if you copy and paste a url from the Hetzner console GUI, some characters can get replaced (If you are using an English/US keyboard layout for example). Just replace the offending characters (check the punctuation especially, @:_ and the likes).

--- a/hosters/hetzner-cloud/README.md
+++ b/hosters/hetzner-cloud/README.md
@@ -5,7 +5,7 @@
 3. You won't be able to ssh into your server. You will have to do the following steps by logging in with the Hetzner UI.
 - On the top right of the server details click on the icon `>_`.
 - fork this repo and replace your SSH public key in the script. Make a commit on a new branch for example.
-- get the url of the script you created (should look like https://raw.github.com/YOUR_USER_NAME/nixos-install-scripts/YOUR_BRANCH_NAME/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh)
+- get the url of the script you created (should look like https://raw.github.com/YOUR_USER_NAME/nixos-install-scripts/YOUR_BRANCH_NAME/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh).
 - paste the following command into your console gui `curl -L YOUR_URL | sudo bash`.
 4. on your own computer you can now ssh into the newly created machine.
 

--- a/hosters/hetzner-cloud/README.md
+++ b/hosters/hetzner-cloud/README.md
@@ -3,10 +3,10 @@
 1. Create a server with any distribution (Ubuntu for exemple) from the Hetzner UI.
 2. In your server options on the Hetzner UI click on `Mount image`. Find the NixOS image and mount it.
 3. You won't be able to ssh into your server. You will have to do the following steps by logging in with the Hetzner UI.
-  - On the top right of the server details click on the icon `>_`.
-  - fork this repo and replace your SSH public key in the script. Make a commit on a new branch for example.
-  - get the url of the script you created (should look like https://raw.github.com/YOUR_USER_NAME/nixos-install-scripts/YOUR_BRANCH_NAME/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh).
-  - paste the following command into your console gui `curl -L YOUR_URL | sudo bash`.
+    - On the top right of the server details click on the icon `>_`.
+    - fork this repo and replace your SSH public key in the script. Make a commit on a new branch for example.
+    - get the url of the script you created (should look like https://raw.github.com/YOUR_USER_NAME/nixos-install-scripts/YOUR_BRANCH_NAME/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh).
+    - paste the following command into your console gui `curl -L YOUR_URL | sudo bash`.
 4. on your own computer you can now ssh into the newly created machine.
 
 # Troubleshooting


### PR DESCRIPTION
I was thinking of separating the install instructions and detail a little more.

I ran into some of the problems mentioned in the install script and I thought I would make them clearer.

This is just a suggestion, I'm happy to amend.

I was thinking of potentially adding screeshots?
and/or removing the instructions from the script directly.