### PR TITLE
hetzner-cloud: Use `poweroff` instead of `reboot`.

### DIFF
--- a/hosters/hetzner-cloud/README.md
+++ b/hosters/hetzner-cloud/README.md
@@ -7,7 +7,9 @@
     - Fork this repo and replace your SSH public key in the script. For exapmle, make a commit on a new branch.
     - Get the URL of the script you created (might look like `https://raw.github.com/YOUR_USER_NAME/nixos-install-scripts/YOUR_BRANCH_NAME/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh`).
     - Paste the following command into your console gui `curl -L YOUR_URL | sudo bash`.
-4. on your own computer you can now ssh into the newly created machine.
+   This will install NixOS and turn the server off.
+4. In your server options on the Hetzner UI click on `Unmount`, and turn the server back on using the big power-switch button in the top right.
+5. On your own computer you can now ssh into the newly created machine.
 
 # Troubleshooting
 

--- a/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh
+++ b/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh
@@ -17,8 +17,10 @@
 #
 #       # Replace this URL by your own that has your pubkey in
 #       curl -L https://raw.githubusercontent.com/nix-community/nixos-install-scripts/master/hosters/hetzner-cloud/nixos-install-hetzner-cloud.sh | sudo bash
+#
+#    This will install NixOS and power off the server.
 # 4. Unmount the ISO image from the Hetzner Cloud GUI.
-# 5. Reboot.
+# 5. Turn the server back on from the Hetzner Cloud GUI.
 #
 # To run it from the Hetzner Cloud web terminal without typing it down,
 # you can either select it and then middle-click onto the web terminal, (that pastes
@@ -71,4 +73,4 @@ echo '
 
 nixos-install --no-root-passwd
 
-reboot
+poweroff


### PR DESCRIPTION
Reduces chance of users not noticing that without unmounting
the image, they'll boot back into the NixOS installer.