### PR TITLE
hosters/hetzner-dedicated: mdadm: ignore homehost

### DIFF
--- a/hosters/hetzner-dedicated/hetzner-dedicated-wipe-and-install-nixos.sh
+++ b/hosters/hetzner-dedicated/hetzner-dedicated-wipe-and-install-nixos.sh
@@ -229,13 +229,11 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
   # This is mdadm's protection against accidentally putting a RAID disk
   # into the wrong machine and corrupting data by accidental sync, see
   # https://bugzilla.redhat.com/show_bug.cgi?id=606481#c14 and onward.
-  # We set the HOMEHOST manually go get the short '/dev/md' names,
-  # and so that things look and are configured the same on all such
-  # machines irrespective of host names.
   # We do not worry about plugging disks into the wrong machine because
-  # we will never exchange disks between machines.
+  # we will never exchange disks between machines, so we tell mdadm to
+  # ignore the homehost entirely.
   environment.etc."mdadm.conf".text = ''
-    HOMEHOST hetzner
+    HOMEHOST <ignore>
   '';
   # The RAIDs are assembled in stage1, so we need to make the config
   # available there.


### PR DESCRIPTION
This is a safer way of ensuring there are no issues when auto-assembling
RAID arrays, since we skip the homehost validation altogether.