### PR TITLE
General improvements and fixes

### DIFF
--- a/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
+++ b/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
@@ -224,7 +224,7 @@ nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs
 nix-channel --update
 
 # Getting NixOS installation tools
-nix-env -iE "_: with import <nixpkgs/nixos> { configuration = {}; }; with config.system.build; [ nixos-generate-config nixos-install nixos-enter manual.manpages ]"
+nix-env -iE "_: with import <nixpkgs/nixos> { configuration = {}; }; with pkgs; [ nixos-install-tools ]"
 
 nixos-generate-config --root /mnt
 

--- a/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
+++ b/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
@@ -234,7 +234,7 @@ nixos-generate-config --root /mnt
 INTERFACE=$(udevadm info -e | grep -A 11 ^P.*eth0 | grep -o -E 'ID_NET_NAME_ONBOARD=\w+' | cut -d= -f2)
 echo "Determined INTERFACE as $INTERFACE"
 
-IP_V4=$(ip route get 8.8.8.8 | head -1 | cut -d' ' -f8)
+IP_V4=$(ip route get 8.8.8.8 | head -1 | cut -d' ' -f7)
 echo "Determined IP_V4 as $IP_V4"
 
 # From https://stackoverflow.com/questions/1204629/how-do-i-get-the-default-gateway-in-linux-given-the-destination/15973156#15973156

--- a/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
+++ b/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
@@ -114,6 +114,12 @@ udevadm settle --timeout=5 --exit-if-exists=/dev/sdc2
 udevadm settle --timeout=5 --exit-if-exists=/dev/sdd1
 udevadm settle --timeout=5 --exit-if-exists=/dev/sdd2
 
+# Array gets created automatically
+# Stop it so mdadm can zero the superblock
+for f in $(ls -p /dev | grep -v / | grep md); do
+  mdadm --stop /dev/$f
+done
+
 # Wipe any previous RAID signatures
 mdadm --zero-superblock /dev/sda2
 mdadm --zero-superblock /dev/sda3

--- a/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
+++ b/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
@@ -210,7 +210,7 @@ set +u +x # sourcing this may refer to unset variables that we have no control o
 . $HOME/.nix-profile/etc/profile.d/nix.sh
 set -u -x
 
-nix-channel --add https://nixos.org/channels/nixos-19.03 nixpkgs
+nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs
 nix-channel --update
 
 # Getting NixOS installation tools
@@ -315,7 +315,7 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
   # compatible, in order to avoid breaking some software such as database
   # servers. You should change this only after NixOS release notes say you
   # should.
-  system.stateVersion = "19.03"; # Did you read the comment?
+  system.stateVersion = "24.05"; # Did you read the comment?
 
 }
 EOF

--- a/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
+++ b/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
@@ -210,8 +210,12 @@ mount /dev/disk/by-label/esp1 /mnt/boot/ESP1
 #   https://github.com/NixOS/nix/issues/936#issuecomment-475795730
 mkdir -p /etc/nix
 echo "build-users-group =" > /etc/nix/nix.conf
+echo "sandbox = false" >> /etc/nix/nix.conf
 
-curl -L https://nixos.org/nix/install | sh
+# https://github.com/NixOS/nix/issues/7790#issuecomment-1451990482
+mount --bind / /
+
+curl -L https://nixos.org/nix/install | sh -s -- --daemon --yes
 set +u +x # sourcing this may refer to unset variables that we have no control over
 . $HOME/.nix-profile/etc/profile.d/nix.sh
 set -u -x

--- a/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
+++ b/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
@@ -8,6 +8,7 @@
 # Prerequisites:
 #   * Create a LUKS key file at /root/benacofs-luks-key
 #     e.g. by copying it up.
+#     See https://wiki.archlinux.org/title/Dm-crypt/Device_encryption#Keyfiles
 #   * Update the script to put in your SSH pubkey, adjust hostname, NixOS version etc.
 #
 # Usage:

--- a/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
+++ b/hosters/ovh-dedicated/ovh-dedicated-wipe-and-install-nixos.sh
@@ -261,13 +261,6 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
   # boot is just on the / partition.
   boot.loader.efi.efiSysMountPoint = "/boot/EFI";
 
-  # OVH has an issue where on newer kernels, it can take up to 20 minutes
-  # for the default gateway to not be 'linkdown' when booting. See #812.
-  # We observed that with the 4.15 kernels so far, including OVH's own
-  # Ubuntu 18.04.
-  # Our workaround so far is to use the 4.9 kernel.
-  boot.kernelPackages = pkgs.linuxPackages_4_9;
-
   networking.hostName = "benaco-cdn-na1";
 
   # The mdadm RAID1s were created with 'mdadm --create ... --homehost=benaco-cdn',


### PR DESCRIPTION
- Closes https://github.com/nix-community/nixos-install-scripts/issues/12
- Makes it easier to edit path, hostname and fsname
- Disable sandboxing which prevents the install
- Fix ipv4 detection
- Update to nixos 24.05
- Fix install tools installation

The only problem left is with the install itself and nix-channel update:
```
nix-channel --update 
unpacking 1 channels...
error:
       … while setting up the build environment

       error: cannot pivot old root directory onto '/nix/store/dy8qb5adj97cfmmf4ah5p07gbs0x1hib-nixpkgs-24.05.drv.chroot/root/real-root': Invalid argument
error: program '/nix/store/hdy82qidsybc3fg561pqfwagv44vschb-nix-2.24.10/bin/nix-env' failed with exit code 1
```

This is documented https://github.com/NixOS/nix/issues/7790 but I'm not quite sure how to fix it yet.
```
mount --bind / /
```

Helped but doesn't allow for the install completion.

I still believe this PR might be worth merging as it fixes quite a lot of issues. I'll make another PR if I manage to fix the pivot error.