### PR TITLE
Hetzner dedicated must use /32 to be able to ping machines in same subnet; also NixOS update

### DIFF
--- a/hosters/hetzner-dedicated/hetzner-dedicated-wipe-and-install-nixos.sh
+++ b/hosters/hetzner-dedicated/hetzner-dedicated-wipe-and-install-nixos.sh
@@ -273,7 +273,9 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
 
   # Initial empty root password for easy login:
   users.users.root.initialHashedPassword = "";
-  services.openssh.permitRootLogin = "prohibit-password";
+  services.openssh.settings = {
+    PermitRootLogin = "prohibit-password";
+  };
 
   users.users.root.openssh.authorizedKeys.keys = [
     # FIXME Replace this by your SSH pubkey!

--- a/hosters/hetzner-dedicated/hetzner-dedicated-wipe-and-install-nixos.sh
+++ b/hosters/hetzner-dedicated/hetzner-dedicated-wipe-and-install-nixos.sh
@@ -249,13 +249,12 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
   networking.interfaces."$NIXOS_INTERFACE".ipv4.addresses = [
     {
       address = "$IP_V4";
-      # FIXME: The prefix length is commonly, but not always, 24.
-      # You should check what the prefix length is for your server
-      # by inspecting the netmask in the "IPs" tab of the Hetzner UI.
-      # For example, a netmask of 255.255.255.0 means prefix length 24
-      # (24 leading 1s), and 255.255.255.192 means prefix length 26
-      # (26 leading 1s).
-      prefixLength = 24;
+      # Hetzner requires /32, see:
+      #     https://docs.hetzner.com/robot/dedicated-server/network/net-config-debian-ubuntu/#ipv4.
+      # NixOS automatically sets up a route to the gateway
+      # (but only because we set "networking.defaultGateway.interface" below), see
+      #     https://github.com/NixOS/nixops/pull/1032#issuecomment-2763497444
+      prefixLength = 32;
     }
   ];
   networking.interfaces."$NIXOS_INTERFACE".ipv6.addresses = [
@@ -264,7 +263,11 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
       prefixLength = 64;
     }
   ];
-  networking.defaultGateway = "$DEFAULT_GATEWAY";
+  networking.defaultGateway = {
+    address = "$DEFAULT_GATEWAY";
+    # Interface must be given for Hetzner networking to work, see comment above.
+    interface = "$NIXOS_INTERFACE";
+  };
   networking.defaultGateway6 = { address = "fe80::1"; interface = "$NIXOS_INTERFACE"; };
   networking.nameservers = [ "8.8.8.8" ];
 

--- a/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
+++ b/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
@@ -265,14 +265,23 @@ mount /dev/md127 /mnt/boot/efi
 
 # Installing nix
 
+# Installing nix requires `sudo`; the Hetzner rescue mode doesn't have it.
+apt-get install -y sudo
+
 # Allow installing nix as root, see
 #   https://github.com/NixOS/nix/issues/936#issuecomment-475795730
 mkdir -p /etc/nix
 echo "build-users-group =" > /etc/nix/nix.conf
 
-# using determinate systems installer, for more information
-# check https://github.com/DeterminateSystems/nix-installer
-curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+# Allow installing nix as root, see
+#   https://github.com/NixOS/nix/issues/936#issuecomment-475795730
+mkdir -p /etc/nix
+echo "build-users-group =" > /etc/nix/nix.conf
+
+curl -L https://nixos.org/nix/install | sh
+set +u +x # sourcing this may refer to unset variables that we have no control over
+. $HOME/.nix-profile/etc/profile.d/nix.sh
+set -u -x
 
 # FIXME Keep in sync with `system.stateVersion` set below!
 nix-channel --add https://nixos.org/channels/nixos-24.11 nixpkgs

--- a/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
+++ b/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
@@ -67,23 +67,34 @@ lsblk
 # check the disks that you have available
 # you have to use disks by ID with zfs
 # see https://openzfs.github.io/openzfs-docs/Getting%20Started/Ubuntu/Ubuntu%2020.04%20Root%20on%20ZFS.html#step-2-disk-formatting
-ls /dev/disk/by-id
+ls -1 /dev/disk/by-id
 # should give you something like this
-# md-name-rescue:0                             nvme-eui.0025388a01051b58-part1
-# md-name-rescue:1                             nvme-eui.0025388a01051b58-part2
-# md-name-rescue:2                             nvme-eui.0025388a01051b58-part3
-# md-uuid-15391820:32e070f6:ecbfb99e:e983e018  nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00424
-# md-uuid-48379d14:3c44fe11:e6528eec:ad784ade  nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00424-part1
-# md-uuid-f2a894fc:9e90e3af:9af81d28:b120ae1f  nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00424-part2
-# nvme-eui.0025388a01051b55                    nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00424-part3
-# nvme-eui.0025388a01051b55-part1              nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00427
-# nvme-eui.0025388a01051b55-part2              nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00427-part1
-# nvme-eui.0025388a01051b55-part3              nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00427-part2
-# nvme-eui.0025388a01051b58                    nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00427-part3
+#     md-name-rescue:0
+#     md-name-rescue:1
+#     md-name-rescue:2
+#     md-uuid-15391820:32e070f6:ecbfb99e:e983e018
+#     md-uuid-48379d14:3c44fe11:e6528eec:ad784ade
+#     md-uuid-f2a894fc:9e90e3af:9af81d28:b120ae1f
+#     nvme-eui.0025388a01051b55
+#     nvme-eui.0025388a01051b55-part1
+#     nvme-eui.0025388a01051b55-part2
+#     nvme-eui.0025388a01051b55-part3
+#     nvme-eui.0025388a01051b58
+#     nvme-eui.0025388a01051b58-part1
+#     nvme-eui.0025388a01051b58-part2
+#     nvme-eui.0025388a01051b58-part3
+#     nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00424
+#     nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00424-part1
+#     nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00424-part2
+#     nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00424-part3
+#     nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00427
+#     nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00427-part1
+#     nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00427-part2
+#     nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00427-part3
 #
 # we will use the two disks
-# nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00424
-# nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00427
+#     nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00424
+#     nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00427
 
 # FIXME The following variables should be replaced
 export DISK1=/dev/disk/by-id/nvme-SAMSUNG_MZQLB3T8HALS-00007_S438NC0R804840

--- a/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
+++ b/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
@@ -269,12 +269,12 @@ echo "build-users-group =" > /etc/nix/nix.conf
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
 
 # FIXME Keep in sync with `system.stateVersion` set below!
-nix-channel --add https://nixos.org/channels/nixos-23.05 nixpkgs
+nix-channel --add https://nixos.org/channels/nixos-24.11 nixpkgs
 nix-channel --update
 
 # TODO use something like nix shell nixpkgs#nixos-generate-config nixpkgs#nixos-install nixpkgs#nixos-enter nixpkgs#manual.manpages
 # Getting NixOS installation tools
-nix-env -iE "_: with import <nixpkgs/nixos> { configuration = {}; }; with config.system.build; [ nixos-generate-config nixos-install nixos-enter manual.manpages ]"
+nix-env -iE "_: with import <nixpkgs/nixos> { configuration = {}; }; (with config.system.build; [ nixos-generate-config nixos-install ]) ++ (with pkgs; [ nixos-enter ])"
 
 # TODO
 # perl: warning: Please check that your locale settings:
@@ -399,7 +399,7 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
   # compatible, in order to avoid breaking some software such as database
   # servers. You should change this only after NixOS release notes say you
   # should.
-  system.stateVersion = "23.05"; # Did you read the comment?
+  system.stateVersion = "24.11"; # Did you read the comment?
 }
 EOF
 

--- a/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
+++ b/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
@@ -189,12 +189,29 @@ udevadm trigger
 
 # taken from https://nixos.wiki/wiki/NixOS_on_ZFS
 # somehow there is a weird symlink in the default zfs
+#
+# `-o compatibility=grub2` is needed because this
+# script makes GRUB boot from root-on-ZFS (there's
+# no separate non-ZFS `/boot` that contains kernels
+# and initrds).
+# Without it,`nixos-install` fails with
+#     grub-install: error: unknown filesystem
+# since GRUB's installer iteslf already tries to read the ZFS
+# filesystem, and that fails if ZFS uses features that
+# GRUB's ZFS support does not understand.
+# See https://discourse.nixos.org/t/failing-to-successfully-install-grub-on-zfs-please-help/55387/9
+# TODO: It would be better to not do it this way,
+#       and instead install kernels/initrd outside
+#       of ZFS because GRUB does not do error
+#       recovery using mirrors, see
+#       https://discourse.nixos.org/t/disko-partition-setup-on-uefi-system-which-has-fallback-boot-partition/51968/2?u=nh2
 zpool create -O mountpoint=none \
     -O atime=off \
     -O compression=lz4 \
     -O xattr=sa \
     -O acltype=posixacl \
     -o ashift=12 \
+    -o compatibility=grub2 \
     -f \
     root_pool mirror $DISK1-part3 $DISK2-part3
 

--- a/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
+++ b/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
@@ -445,6 +445,7 @@ EOF
 # Install NixOS
 PATH="$PATH" $(which nixos-install) --no-root-passwd --root /mnt --max-jobs 40
 
+umount /mnt/boot/efi
 umount /mnt
 
 reboot

--- a/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
+++ b/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
@@ -4,6 +4,8 @@
 #
 # This is for a specific server configuration; adjust where needed.
 #
+# Prerequisites:
+#   * Update the script wherever FIXME is present
 #
 # Usage:
 #     ssh root@YOUR_SERVERS_IP bash -s < hetzner-dedicated-wipe-and-install-nixos.sh
@@ -88,11 +90,11 @@ ls /dev/disk/by-id
 # nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00424
 # nvme-SAMSUNG_MZVLB512HBJQ-00000_S4GENA0NA00427
 
-# The following variables should be replaced
+# FIXME The following variables should be replaced
 export DISK1=/dev/disk/by-id/nvme-SAMSUNG_MZQLB3T8HALS-00007_S438NC0R804840
 export DISK2=/dev/disk/by-id/nvme-SAMSUNG_MZQLB3T8HALS-00007_S438NC0R811800
-# Replace with your key
-export SSH_PUB_KEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGyQSeQ0CV/qhZPre37+Nd0E9eW+soGs+up6a/bwggoP raphael@RAPHAELs-MacBook-Pro.local"
+# FIXME Replace this by your SSH pubkey!
+export SSH_PUB_KEY="AAAAAAAAAAA..."
 # choose whatever you want, it doesn't matter
 export MY_HOSTNAME=htz
 # this has to be a number in this format exactly. You can replace the numbers though
@@ -266,7 +268,7 @@ echo "build-users-group =" > /etc/nix/nix.conf
 # check https://github.com/DeterminateSystems/nix-installer
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
 
-# Keep in sync with `system.stateVersion` set below!
+# FIXME Keep in sync with `system.stateVersion` set below!
 nix-channel --add https://nixos.org/channels/nixos-23.05 nixpkgs
 nix-channel --update
 
@@ -392,6 +394,7 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
 
   services.openssh.enable = true;
 
+  # FIXME
   # This value determines the NixOS release with which your system is to be
   # compatible, in order to avoid breaking some software such as database
   # servers. You should change this only after NixOS release notes say you

--- a/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
+++ b/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
@@ -361,14 +361,6 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
   networking.hostName = "$MY_HOSTNAME";
   networking.hostId = "$MY_HOSTID";
   
-  # enable flakes by default
-  nix = {
-    package = pkgs.nixFlakes;
-    extraOptions = ''
-      experimental-features = nix-command flakes
-    '';
-  };
-
   # Set your time zone.
   time.timeZone = "Etc/UTC";
 

--- a/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
+++ b/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
@@ -363,7 +363,12 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
   networking.interfaces."$NIXOS_INTERFACE".ipv4.addresses = [
     {
       address = "$IP_V4";
-      prefixLength = 24;
+      # Hetzner requires /32, see:
+      #     https://docs.hetzner.com/robot/dedicated-server/network/net-config-debian-ubuntu/#ipv4.
+      # NixOS automatically sets up a route to the gateway
+      # (but only because we set "networking.defaultGateway.interface" below), see
+      #     https://github.com/NixOS/nixops/pull/1032#issuecomment-2763497444
+      prefixLength = 32;
     }
   ];
   networking.interfaces."$NIXOS_INTERFACE".ipv6.addresses = [
@@ -372,7 +377,11 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
       prefixLength = 64;
     }
   ];
-  networking.defaultGateway = "$DEFAULT_GATEWAY";
+  networking.defaultGateway = {
+    address = "$DEFAULT_GATEWAY";
+    # Interface must be given for Hetzner networking to work, see comment above.
+    interface = "$NIXOS_INTERFACE";
+  };
   networking.defaultGateway6 = { address = "fe80::1"; interface = "$NIXOS_INTERFACE"; };
   networking.nameservers = [
     # cloudflare

--- a/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
+++ b/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
@@ -408,7 +408,9 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
 
   # Initial empty root password for easy login:
   users.users.root.initialHashedPassword = "";
-  services.openssh.permitRootLogin = "prohibit-password";
+  services.openssh.settings = {
+    PermitRootLogin = "prohibit-password";
+  };
 
   users.users.root.openssh.authorizedKeys.keys = ["$SSH_PUB_KEY"];
 

--- a/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
+++ b/hosters/hetzner-dedicated/zfs-uefi-nvme-nixos.sh
@@ -426,8 +426,7 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
 EOF
 
 # Install NixOS
-PATH="$PATH" $(which nixos-install) \
-  --no-root-passwd --root /mnt --max-jobs 40
+PATH="$PATH" $(which nixos-install) --no-root-passwd --root /mnt --max-jobs 40
 
 umount /mnt
 


### PR DESCRIPTION
See https://github.com/NixOS/nixops/pull/1032#issuecomment-2763497444

@happysalada I couldn't test the NixOS version upgrade for `zfs-uefi-nvme-nixos.sh`, could you do that?

You likely have to replay the changes I made to `hetzner-dedicated-wipe-and-install-nixos.sh` in commit `hetzner-dedicated: Update NixOS version to NixOS 24.11`.