### PR TITLE
hetzner-dedicated-wipe-and-install-nixos: update to 25.05

### DIFF
--- a/hosters/hetzner-dedicated/hetzner-dedicated-wipe-and-install-nixos.sh
+++ b/hosters/hetzner-dedicated/hetzner-dedicated-wipe-and-install-nixos.sh
@@ -165,7 +165,7 @@ set +u +x # sourcing this may refer to unset variables that we have no control o
 set -u -x
 
 # FIXME Keep in sync with `system.stateVersion` set below!
-nix-channel --add https://nixos.org/channels/nixos-24.11 nixpkgs
+nix-channel --add https://nixos.org/channels/nixos-25.05 nixpkgs
 nix-channel --update
 
 # Getting NixOS installation tools.
@@ -289,7 +289,7 @@ cat > /mnt/etc/nixos/configuration.nix <<EOF
   # compatible, in order to avoid breaking some software such as database
   # servers. You should change this only after NixOS release notes say you
   # should.
-  system.stateVersion = "24.11"; # Did you read the comment?
+  system.stateVersion = "25.05"; # Did you read the comment?
 
 }
 EOF


### PR DESCRIPTION
Move from 24.11 Vicuña to the new 25.05 Warbler

Tested working on:

```
1 x Dedicated Server "Server Auction"
     * Intel Core i7-7700
     * 2x SSD SATA 512 GB
     * 4x RAM 16384 MB DDR4
     * NIC 1 Gbit Intel I219-LM
     * Rescue system (English)
     * 1 x Primary IPv4
```

```
[root@hetzner:~]# nixos-version
25.05.804002.5f4f306bea96 (Warbler)

[root@hetzner:~]# uname -a
Linux hetzner 6.12.33 #1-NixOS SMP PREEMPT_DYNAMIC Tue Jun 10 11:13:00 UTC 2025 x86_64 GNU/Linux
```